### PR TITLE
Feature/pcolarco/change name convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Changed naming convention so that output of runoptics.py files are labeled ".nomom." to 
+  explicitly indicate that expansion moments are not included; post-processing by rungsf.py
+  now results in a filename that strips out ".nomom" and so looks like classic files
+- Modify processing script (proc.v2.0.0.csh) to accommodate the above change
+
 ### Fixed
 - fixed eval_gsfun script for legendre overflows and bad indexing of scattering phase functions when plotting
 ### Added

--- a/dointegration.py
+++ b/dointegration.py
@@ -205,12 +205,12 @@ def find_closest_ind(myList, myNumber, typ='none',ide=''):
 def createNCDF(ncdfID, oppfx, rarr, rharr, lambarr, ang, oppclassic):
 
   if oppclassic:
-    ncdf = netCDF4.Dataset(os.path.join(oppfx, 'optics_%s.legacy.nc4'%ncdfID), 'w')
+    ncdf = netCDF4.Dataset(os.path.join(oppfx, 'optics_%s.nomom.legacy.nc4'%ncdfID), 'w')
     radiusNm = 'radius'
     lambdaNm = 'lambda'
     npolNm   = 'nPol'
   else:
-    ncdf = netCDF4.Dataset(os.path.join(oppfx, 'optics_%s.nc4'%ncdfID), 'w')
+    ncdf = netCDF4.Dataset(os.path.join(oppfx, 'optics_%s.nomom.nc4'%ncdfID), 'w')
     radiusNm = 'bin'
     lambdaNm = 'wavelength'
     npolNm   = 'p'

--- a/gsf/convertncdf.py
+++ b/gsf/convertncdf.py
@@ -319,16 +319,13 @@ def fun(fn, whichproc, rhop0, ice, keydic):
 def processFileRaw(infile, outdir, whichproc, rhop0, mode, ice):
   # mischenko expects the order p11, p22, p33, p44, p12, p34
   #numExpand = 2001 # this needs to match what is set in params.h
-  #numExpand = 300 
+  #numExpand = 1000 
   numExpand = 129 
   num_gauss = 960 # arbitrary? perhaps try adaptive
   # mishchenko's code gives errors in num_gauss is bigger than 1000, though this can probably be changed in params.h
 
   fn = os.path.basename(infile)
-  sfx = fn.split('.')[-1] # file suffix
-  outfn = fn.replace(sfx, 'GSFun.%s'%sfx)
-  if numExpand != 2001:
-    outfn = outfn.replace('.GSFun.%s'%sfx, '.GSFun-%d.%s'%(numExpand, sfx))
+  outfn = fn.replace('nomom.','')
 
   outfile = os.path.join(outdir, outfn)
 

--- a/runoptics.py
+++ b/runoptics.py
@@ -107,9 +107,9 @@ if __name__ == "__main__":
     # that is prepended to the results of the initial hydrophilic 
     # calculation
     if options.classic:
-      opfn = "optics_%s.legacy.nc4"%particlename
+      opfn = "optics_%s.nomom.legacy.nc4"%particlename
     else:
-      opfn = "optics_%s.nc4"%particlename
+      opfn = "optics_%s.nomom.nc4"%particlename
     if "hydrophobic" in params and params["hydrophobic"]:
       # rename non-HP file 
       fn2 = "%s.nohp"%opfn

--- a/scripts/proc.v2.0.0.csh
+++ b/scripts/proc.v2.0.0.csh
@@ -30,19 +30,19 @@ mkdir -p ../AerosolOptics/$ver/x
 # Run the cases
 
 # All wavelengths
-  foreach XX (DU BC OC NI SS SU BR)
+  foreach XX (DU BC OC SU BR NI SS)
    ./runoptics.py --name $ver/$XX.$ver.json --dest=$ver> $ver/optics_$XX.$ver.txt &
   end
   wait
 
-# Bands
-  foreach XX (DU BC OC NI SS SU BR)
-   ./runbands.py --filename $ver/optics_$XX.$ver.nc4 --dest=$ver
+# Add phase matrices
+  foreach XX (DU BC OC SU BR NI SS)
+   ./rungsf.py --filename $ver/optics_$XX.$ver.nomom.nc4 --dest=$ver
   end
 
-# Add phase matrices
-  foreach XX (DU BC OC NI SS SU BR)
-   ./rungsf.py --filename $ver/optics_$XX.$ver.nc4 --dest=$ver
+# Bands
+  foreach XX (DU BC OC SU BR NI SS)
+   ./runbands.py --filename $ver/optics_$XX.$ver.nc4 --dest=$ver
   end
 
 # Move files
@@ -50,5 +50,5 @@ mkdir -p ../AerosolOptics/$ver/x
 
 
 # Clean up
-  rm -f runbands.py runoptics.py rungsf.py a.out
+#  rm -f runbands.py runoptics.py rungsf.py a.out
 


### PR DESCRIPTION
This modification changes the naming conventions for the files generated, so that output from run runoptics.py now has ".nomom" explicitly in the filename to indicate the lack of moments expansion. Subsequent post-processing by rungsf.py strips out the ".nomom" in favor of something that looks like the classic filenames.