### PR TITLE
prc: fix reported units for mass backscatter efficiency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- fixed units for mass backscattering efficiency to correctly reflect they are
+  in units of m2 kg-1 sr-1
 
 ### Added
 

--- a/src/geosmie/dointegration.py
+++ b/src/geosmie/dointegration.py
@@ -287,7 +287,7 @@ def createNCDF(ncdfID, oppfx, rarr, rharr, lambarr, ang, oppclassic):
   vardict['cext'] = {'units': 'm2', \
   'long_name': 'mass extinction cross-section'
   }
-  vardict['bbck'] = {'units': 'm2 (kg dry mass)-1', \
+  vardict['bbck'] = {'units': 'm2 (kg dry mass)-1 sr-1', \
   'long_name': 'mass backscatter efficiency'
   }
   vardict['lidar_ratio'] = {'units': '', \


### PR DESCRIPTION
The mass backscatter efficiency was being reported with incorrect units. Corrected to be m2 kg-1 sr-1